### PR TITLE
fix travis warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "4.1"


### PR DESCRIPTION
I have been got such as warning:

```
This job is running on container-based infrastructure, which does not allow use of 'sudo', setuid and setguid executables.

If you require sudo, add 'sudo: required' to your .travis.yml

See http://docs.travis-ci.com/user/workers/container-based-infrastructure/ for details.
```

I try to fix this.
